### PR TITLE
Do not start a local bberg process unnecessarily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 /nbactions.xml
 /*.iml
+.idea

--- a/src/main/java/com/assylias/jbloomberg/NetworkUtils.java
+++ b/src/main/java/com/assylias/jbloomberg/NetworkUtils.java
@@ -1,0 +1,31 @@
+package com.assylias.jbloomberg;
+
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+
+final class NetworkUtils {
+    private NetworkUtils () {}
+
+    public static boolean isLocalhost(String host) {
+        try {
+            return isLocalhost(InetAddress.getByName(host));
+        } catch (UnknownHostException e) {
+            return false;
+        }
+    }
+
+    // (C) Kevin Brock @ http://stackoverflow.com/questions/2406341/how-to-check-if-an-ip-address-is-the-local-host-on-a-multi-homed-system
+    public static boolean isLocalhost(InetAddress addr) {
+        if (addr.isAnyLocalAddress() || addr.isLoopbackAddress()) {
+            return true;
+        }
+
+        try {
+            return NetworkInterface.getByInetAddress(addr) != null;
+        } catch (SocketException e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
There is no need in a local bberg process when only remote hosts
are specified in the session options. 

Cannot run the full test suite as I don't have a bberg terminal locally nor a Windows machine handy.