### PR TITLE
Refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+jdk:
+ - openjdk8
+
+before_script:
+ - wget -q https://software.tech.bloomberg/BLPAPI-Stable-Generic/blpapi_java_3.8.8.2.zip
+ - unzip blpapi_java_3.8.8.2.zip
+ - mvn install:install-file -Dfile=blpapi_java_3.8.8.2/bin/blpapi-3.8.8-2.jar -DgroupId=com.bloombergblp -DartifactId=blpapi -Dversion=3.8.8-2 -Dpackaging=jar
+
+script:
+ - mvn test -Dgroups=unit

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 jdk:
  - openjdk8
 
-before_script:
+before_install:
  - wget -q https://software.tech.bloomberg/BLPAPI-Stable-Generic/blpapi_java_3.8.8.2.zip
  - unzip blpapi_java_3.8.8.2.zip
  - mvn install:install-file -Dfile=blpapi_java_3.8.8.2/bin/blpapi-3.8.8-2.jar -DgroupId=com.bloombergblp -DartifactId=blpapi -Dversion=3.8.8-2 -Dpackaging=jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
  - mvn install:install-file -Dfile=blpapi_java_3.8.8.2/bin/blpapi-3.8.8-2.jar -DgroupId=com.bloombergblp -DartifactId=blpapi -Dversion=3.8.8-2 -Dpackaging=jar
 
 script:
- - mvn test -Dgroups=unit
+ - mvn test -Dgroups=unit -DexcludedGroups=windows

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Although most features of the underlying Bloomberg API are available, some optio
 
 You can browse the [javadoc](http://assylias.github.com/jBloomberg/apidocs/index.html) for more information, including example usages on the package page.
 
+[![Build Status](https://travis-ci.org/assylias/jBloomberg.svg?branch=master)](https://travis-ci.org/assylias/jBloomberg)
+
 ### Requirements
 
 **As of v3, Java 8 is required.**

--- a/src/main/java/com/assylias/jbloomberg/AbstractRequestResult.java
+++ b/src/main/java/com/assylias/jbloomberg/AbstractRequestResult.java
@@ -4,6 +4,8 @@
  */
 package com.assylias.jbloomberg;
 
+import com.google.common.collect.ImmutableSet;
+
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.HashSet;
@@ -30,12 +32,12 @@ abstract class AbstractRequestResult implements RequestResult {
 
     @Override
     public synchronized Set<String> getFieldErrors() {
-        return fieldErrors;
+        return ImmutableSet.copyOf(fieldErrors);
     }
 
     @Override
     public synchronized Set<String> getSecurityErrors() {
-        return securityErrors;
+        return ImmutableSet.copyOf(securityErrors);
     }
 
     synchronized void addSecurityError(String security) {
@@ -44,25 +46,5 @@ abstract class AbstractRequestResult implements RequestResult {
 
     synchronized void addFieldError(String field) {
         fieldErrors.add(field);
-    }
-
-    //for HistoricalData
-    void add(LocalDate date, String security, String field, Object value) {
-        throw new UnsupportedOperationException("Subclasses need to override this method if it is required");
-    }
-
-    //for IntradayBarData and IntradayTickData
-    void add(OffsetDateTime date, String field, Object value) {
-        throw new UnsupportedOperationException("Subclasses need to override this method if it is required");
-    }
-
-    //for ReferenceData
-    void add(String security, String field, Object value) {
-        throw new UnsupportedOperationException("Subclasses need to override this method if it is required");
-    }
-
-    //for InstrumentList
-    void add(String security, String description) {
-        throw new UnsupportedOperationException("Subclasses need to override this method if it is required");
     }
 }

--- a/src/main/java/com/assylias/jbloomberg/HistoricalData.java
+++ b/src/main/java/com/assylias/jbloomberg/HistoricalData.java
@@ -73,7 +73,6 @@ public final class HistoricalData extends AbstractRequestResult {
     /**
      * Adds a value to the HistoricalData structure for that security / field / date combination.
      */
-    @Override
     synchronized void add(LocalDate date, String security, String field, Object value) {
         Table<LocalDate, String, TypedObject> securityTable = data.get(security);
         if (securityTable == null) {

--- a/src/main/java/com/assylias/jbloomberg/HistoricalResultParser.java
+++ b/src/main/java/com/assylias/jbloomberg/HistoricalResultParser.java
@@ -5,52 +5,42 @@
 package com.assylias.jbloomberg;
 
 import com.bloomberglp.blpapi.Element;
+
 import java.time.LocalDate;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- *
  * A ResultParser to parse the responses received from the Bloomberg Session when sending a Historical Data request.
  *
  * This implementation is thread safe as the Bloomberg API might send results through more than one thread.
  */
 final class HistoricalResultParser extends AbstractResultParser<HistoricalData> {
+    public HistoricalResultParser() {
+        super((res, response) -> {
+            if (response.hasElement(SECURITY_DATA, true)) {
+                final Element securityData = response.getElement(SECURITY_DATA);
+                parseSecurityData(res, securityData, (security, fieldDataArray) -> {
+                    // There should be no more error at this point and we can happily parse the interesting portion of the response
+                    final int countData = fieldDataArray.numValues();
+                    for (int i = 0; i < countData; i++) {
+                        final Element fieldData = fieldDataArray.getValueAsElement(i);
+                        final Element firstField = fieldData.getElement(0);
+                        if (!DATE.equals(firstField.name())) {
+                            throw new AssertionError("Date field is supposed to be first but got: " + firstField.name());
+                        }
+                        final LocalDate date = BB_RESULT_DATE_FORMATTER.parse(firstField.getValueAsString(), LocalDate::from);
 
-    private static final Logger logger = LoggerFactory.getLogger(HistoricalResultParser.class);
+                        for (int j = 1; j < fieldData.numElements(); j++) {
+                            final Element field = fieldData.getElement(j);
+                            res.add(date, security, field.name().toString(), BloombergUtils.getSpecificObjectOf(field));
+                        }
+                    }
+                });
+            }
+        });
+    }
 
     @Override
     protected HistoricalData getRequestResult() {
         return new HistoricalData();
-    }
-
-    @Override
-    protected void parseResponseNoResponseError(Element response) {
-        if (response.hasElement(SECURITY_DATA, true)) {
-            Element securityData = response.getElement(SECURITY_DATA);
-            parseSecurityData(securityData);
-        }
-    }
-
-    /**
-     * There should be no more error at this point and we can happily parse the interesting portion of the response
-     *
-     */
-    @Override
-    protected void parseFieldDataArray(String security, Element fieldDataArray) {
-        int countData = fieldDataArray.numValues();
-        for (int i = 0; i < countData; i++) {
-            Element fieldData = fieldDataArray.getValueAsElement(i);
-            Element field = fieldData.getElement(0);
-            if (!DATE.equals(field.name())) {
-                throw new AssertionError("Date field is supposed to be first but got: " + field.name());
-            }
-            LocalDate date = BB_RESULT_DATE_FORMATTER.parse(field.getValueAsString(), LocalDate::from);
-
-            for (int j = 1; j < fieldData.numElements(); j++) {
-                field = fieldData.getElement(j);
-                addField(date, security, field);
-            }
-        }
     }
 }

--- a/src/main/java/com/assylias/jbloomberg/InstrumentList.java
+++ b/src/main/java/com/assylias/jbloomberg/InstrumentList.java
@@ -19,7 +19,6 @@ public class InstrumentList extends AbstractRequestResult {
         return data.isEmpty();
     }
 
-    @Override
     synchronized void add(final String security, final String description) {
         data.add(new Instrument(security, description));
     }

--- a/src/main/java/com/assylias/jbloomberg/InstrumentListResultParser.java
+++ b/src/main/java/com/assylias/jbloomberg/InstrumentListResultParser.java
@@ -7,20 +7,23 @@ public class InstrumentListResultParser extends AbstractResultParser<InstrumentL
     private static final Name RESULTS = Name.getName("results");
     private static final Name DESCRIPTION = Name.getName("description");
 
-    @Override
-    protected InstrumentList getRequestResult() {
-        return new InstrumentList();
+    public InstrumentListResultParser() {
+        super((res, response) -> {
+            if (response.hasElement(RESULTS, true)) {
+                final Element results = response.getElement(RESULTS);
+                final int numResults = results.numValues();
+                for (int i = 0; i < numResults; i++) {
+                    final Element result = results.getValueAsElement(i);
+                    final String security = result.getElementAsString(SECURITY);
+                    final String description = result.getElementAsString(DESCRIPTION);
+                    res.add(security, description);
+                }
+            }
+        });
     }
 
     @Override
-    protected void parseResponseNoResponseError(final Element response) {
-        if (response.hasElement(RESULTS)) {
-            final Element results = response.getElement(RESULTS);
-            final int numResults = results.numValues();
-            for (int i = 0; i < numResults; i++) {
-                final Element result = results.getValueAsElement(i);
-                parseSecurityData(result);
-            }
-        }
+    protected InstrumentList getRequestResult() {
+        return new InstrumentList();
     }
 }

--- a/src/main/java/com/assylias/jbloomberg/IntradayBarData.java
+++ b/src/main/java/com/assylias/jbloomberg/IntradayBarData.java
@@ -75,7 +75,6 @@ public class IntradayBarData extends AbstractRequestResult {
     /**
      * Adds a value to the HistoricalData structure for that security / field / date combination.
      */
-    @Override
     synchronized void add(OffsetDateTime date, String field, Object value) {
         try {
             data.put(date, IntradayBarField.of(field), TypedObject.of(value));

--- a/src/main/java/com/assylias/jbloomberg/IntradayTickData.java
+++ b/src/main/java/com/assylias/jbloomberg/IntradayTickData.java
@@ -77,7 +77,6 @@ public class IntradayTickData extends AbstractRequestResult {
     /**
      * Adds a value to the HistoricalData structure for that security / field / date combination.
      */
-    @Override
     synchronized void add(OffsetDateTime date, String field, Object value) {
         try {
             IntradayTickField f = IntradayTickField.of(field);

--- a/src/main/java/com/assylias/jbloomberg/ReferenceData.java
+++ b/src/main/java/com/assylias/jbloomberg/ReferenceData.java
@@ -70,7 +70,6 @@ public final class ReferenceData extends AbstractRequestResult {
     /**
      * Adds a value to the HistoricalData structure for that security / field / date combination.
      */
-    @Override
     synchronized void add(String security, String field, Object value) {
         data.put(security, field, TypedObject.of(value));
     }

--- a/src/test/java/com/assylias/jbloomberg/AbstractResultParserTest.java
+++ b/src/test/java/com/assylias/jbloomberg/AbstractResultParserTest.java
@@ -17,17 +17,7 @@ public class AbstractResultParserTest {
 
     @BeforeMethod(groups="unit")
     public void beforeMethod() {
-        parser = new AbstractResultParser () {
-            @Override
-            protected void parseResponseNoResponseError(Element response) {
-                throw new UnsupportedOperationException("Not supported yet.");
-            }
-
-            @Override
-            protected AbstractRequestResult getRequestResult() {
-                return null;
-            }
-        };
+        parser = new StubResultParser(() -> null);
     }
 
     @Test(groups="unit", expectedExceptions = TimeoutException.class)

--- a/src/test/java/com/assylias/jbloomberg/BloombergUtilsTest.java
+++ b/src/test/java/com/assylias/jbloomberg/BloombergUtilsTest.java
@@ -63,7 +63,10 @@ public class BloombergUtilsTest {
         assertTrue(BloombergUtils.startBloombergProcessIfNecessary());
     }
 
-    @Test(groups = "unit")
+    /**
+     * Marked requires-bloomberg as test fails if bbcomm.exe not available
+     */
+    @Test(groups = {"unit", "windows"})
     public void test_ProcessNotRunning_StartBbCommFails(@Mocked ShellUtils utils, @Mocked ProcessBuilder pb, @Mocked Process p) throws IOException {
         setBbcommStartedFlag(false);
         new Expectations() {

--- a/src/test/java/com/assylias/jbloomberg/DateUtilsTest.java
+++ b/src/test/java/com/assylias/jbloomberg/DateUtilsTest.java
@@ -24,9 +24,7 @@ import java.time.ZoneOffset;
 import static org.testng.Assert.assertEquals;
 import org.testng.annotations.Test;
 
-/**
- *
- */
+@Test(groups = "unit")
 public class DateUtilsTest {
 
   @Test(expectedExceptions = NullPointerException.class) public void getDateTime_null() {

--- a/src/test/java/com/assylias/jbloomberg/DefaultBloombergSessionTest.java
+++ b/src/test/java/com/assylias/jbloomberg/DefaultBloombergSessionTest.java
@@ -145,7 +145,7 @@ public class DefaultBloombergSessionTest {
         session.submit(mock.getMockInstance()).get(2, TimeUnit.SECONDS);
     }
 
-    @Test(groups = "unit", expectedExceptions = BloombergException.class,
+    @Test(groups = {"unit", "windows"}, expectedExceptions = BloombergException.class,
           expectedExceptionsMessageRegExp = ".*session.*")
     public void testSubmit_SessionStartupFailure() throws Exception {
         MockRequestBuilder<?> request = new MockRequestBuilder<>().serviceType(BloombergServiceType.PAGE_DATA);

--- a/src/test/java/com/assylias/jbloomberg/DefaultBloombergSessionTest.java
+++ b/src/test/java/com/assylias/jbloomberg/DefaultBloombergSessionTest.java
@@ -185,7 +185,7 @@ public class DefaultBloombergSessionTest {
         }
     }
 
-    @Test(groups = "unit", expectedExceptions = CancellationException.class)
+    @Test(groups = "requires-bloomberg", expectedExceptions = CancellationException.class)
     public void testSubmit_RequestCancelled() throws Exception {
         new MockBloombergUtils(true);
         MockRequestBuilder<?> request = new MockRequestBuilder<>().serviceType(BloombergServiceType.PAGE_DATA);

--- a/src/test/java/com/assylias/jbloomberg/EventsKeyTest.java
+++ b/src/test/java/com/assylias/jbloomberg/EventsKeyTest.java
@@ -69,7 +69,7 @@ public class EventsKeyTest {
             try {
                 start.await();
             } catch (InterruptedException ex) {}
-            for (int i = 0; i < 1000; i++) {
+            for (int i = 10_000; i < 11_000; i++) {
                 EventsKey key1 = EventsKey.of(new CorrelationID(i), RealtimeField.ASK);
                 EventsKey key2 = EventsKey.of(new CorrelationID(i), RealtimeField.BID);
                 assertNotEquals(key1, key2); //pretend we are doing something

--- a/src/test/java/com/assylias/jbloomberg/EventsKeyTest.java
+++ b/src/test/java/com/assylias/jbloomberg/EventsKeyTest.java
@@ -48,7 +48,9 @@ public class EventsKeyTest {
         int countKeysStart = countKeys();
         start.countDown();
         executor.shutdown();
-        executor.awaitTermination(1, TimeUnit.SECONDS);
+        if (!executor.awaitTermination(1, TimeUnit.SECONDS)) {
+            fail("Tasks did not complete");
+        }
         int countKeysEnd = countKeys();
         assertEquals(countKeysEnd - countKeysStart, 2000);
     }

--- a/src/test/java/com/assylias/jbloomberg/EventsKeyTest.java
+++ b/src/test/java/com/assylias/jbloomberg/EventsKeyTest.java
@@ -5,14 +5,17 @@
 package com.assylias.jbloomberg;
 
 import com.bloomberglp.blpapi.CorrelationID;
+import org.testng.annotations.Test;
+
 import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.*;
-import org.testng.annotations.Test;
 
 @Test(groups="unit", singleThreaded = true) //single threaded to make sure no other test adds keys at the same time
 public class EventsKeyTest {
@@ -52,7 +55,7 @@ public class EventsKeyTest {
             fail("Tasks did not complete");
         }
         int countKeysEnd = countKeys();
-        assertEquals(countKeysEnd - countKeysStart, 2000);
+        assertThat(countKeysEnd).isEqualTo(countKeysStart + 2000);
     }
 
     private static int countKeys() throws Exception {

--- a/src/test/java/com/assylias/jbloomberg/EventsKeyTest.java
+++ b/src/test/java/com/assylias/jbloomberg/EventsKeyTest.java
@@ -48,7 +48,7 @@ public class EventsKeyTest {
         int countKeysStart = countKeys();
         start.countDown();
         executor.shutdown();
-        if (!executor.awaitTermination(1, TimeUnit.SECONDS)) {
+        if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
             fail("Tasks did not complete");
         }
         int countKeysEnd = countKeys();

--- a/src/test/java/com/assylias/jbloomberg/InstrumentListResultParserTest.java
+++ b/src/test/java/com/assylias/jbloomberg/InstrumentListResultParserTest.java
@@ -1,6 +1,5 @@
 package com.assylias.jbloomberg;
 
-import org.assertj.core.api.Condition;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -8,8 +7,7 @@ import org.testng.annotations.Test;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.testng.Assert.*;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class InstrumentListResultParserTest {
 

--- a/src/test/java/com/assylias/jbloomberg/IntradayBarDataTest.java
+++ b/src/test/java/com/assylias/jbloomberg/IntradayBarDataTest.java
@@ -23,9 +23,9 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
- *
  * @author Yann Le Tallec
  */
+@Test(groups = "unit")
 public class IntradayBarDataTest {
 
     private static final OffsetDateTime NOW = OffsetDateTime.now();

--- a/src/test/java/com/assylias/jbloomberg/IntradayBarResultParserTest.java
+++ b/src/test/java/com/assylias/jbloomberg/IntradayBarResultParserTest.java
@@ -41,12 +41,6 @@ public class IntradayBarResultParserTest {
         assertTrue(data.isEmpty());
     }
 
-    @Test(groups = "unit", expectedExceptions = UnsupportedOperationException.class)
-    public void testParse_CantAddFieldError() throws Exception {
-        IntradayBarResultParser parser = new IntradayBarResultParser(INVALID_SECURITY);
-        parser.addFieldError("");
-    }
-
     @Test(groups = "requires-bloomberg")
     public void testParse_OK() throws Exception {
         IntradayBarRequestBuilder builder = new IntradayBarRequestBuilder("IBM US Equity", NOW.minusDays(5), NOW);

--- a/src/test/java/com/assylias/jbloomberg/IntradayTickDataTest.java
+++ b/src/test/java/com/assylias/jbloomberg/IntradayTickDataTest.java
@@ -12,6 +12,7 @@ import static org.testng.Assert.assertTrue;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+@Test(groups = "unit")
 public class IntradayTickDataTest {
 
     private static final OffsetDateTime NOW = OffsetDateTime.now();

--- a/src/test/java/com/assylias/jbloomberg/IntradayTickResultParserTest.java
+++ b/src/test/java/com/assylias/jbloomberg/IntradayTickResultParserTest.java
@@ -41,12 +41,6 @@ public class IntradayTickResultParserTest {
         assertTrue(data.isEmpty());
     }
 
-    @Test(groups = "unit", expectedExceptions = UnsupportedOperationException.class)
-    public void testParse_CantAddFieldError() throws Exception {
-        IntradayTickResultParser parser = new IntradayTickResultParser(INVALID_SECURITY);
-        parser.addFieldError("");
-    }
-
     @Test(groups = "requires-bloomberg")
     public void testParse_OK() throws Exception {
         RequestBuilder<IntradayTickData> builder = new IntradayTickRequestBuilder("SPX Index", NOW.minusDays(5), NOW)

--- a/src/test/java/com/assylias/jbloomberg/MockRequestBuilder.java
+++ b/src/test/java/com/assylias/jbloomberg/MockRequestBuilder.java
@@ -4,7 +4,6 @@
  */
 package com.assylias.jbloomberg;
 
-import com.bloomberglp.blpapi.Element;
 import com.bloomberglp.blpapi.Request;
 import com.bloomberglp.blpapi.Session;
 import mockit.Mock;
@@ -33,17 +32,9 @@ public class MockRequestBuilder<T extends AbstractRequestResult> extends MockUp<
     }
 
     public ResultParser<T> getResultParser() {
-        return new AbstractResultParser<T> () {
-
-            @Override
-            protected void parseResponseNoResponseError(Element response) {
-                throw new UnsupportedOperationException("Not supported yet.");
-            }
-
-            @Override
-            protected T getRequestResult() {
-                throw new UnsupportedOperationException("Not supported yet.");
-            }
-        };
+        return new StubResultParser<>(() -> {
+            throw new UnsupportedOperationException("Not supported yet.");
+        });
     }
+
 }

--- a/src/test/java/com/assylias/jbloomberg/StubResultParser.java
+++ b/src/test/java/com/assylias/jbloomberg/StubResultParser.java
@@ -1,0 +1,19 @@
+package com.assylias.jbloomberg;
+
+import java.util.function.Supplier;
+
+final class StubResultParser<T extends AbstractRequestResult> extends AbstractResultParser<T> {
+    private final Supplier<T> factory;
+
+    StubResultParser(final Supplier<T> factory) {
+        super((res, response) -> {
+            throw new UnsupportedOperationException("Not supported yet.");
+        });
+        this.factory = factory;
+    }
+
+    @Override
+    protected T getRequestResult() {
+        return factory.get();
+    }
+}

--- a/src/test/java/com/assylias/jbloomberg/TypedObjectTest.java
+++ b/src/test/java/com/assylias/jbloomberg/TypedObjectTest.java
@@ -28,6 +28,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+@Test(groups = "unit")
 public class TypedObjectTest {
 
   @Test(expectedExceptions = NullPointerException.class)

--- a/src/test/java/com/assylias/jbloomberg/packageInfo/PackageInfoTest.java
+++ b/src/test/java/com/assylias/jbloomberg/packageInfo/PackageInfoTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-@Test(groups="unit")
+@Test(groups="requires-bloomberg")
 public class PackageInfoTest {
 
     private static final BloombergSession session = new DefaultBloombergSession();


### PR DESCRIPTION

Refactoring to remove inherited methods which throw  …
 - AbstractRequestResult
   - #add removed
   - wrapped errors in ImmutableSet
 - AbstractResultParser
   - parseResponseNoResponseError changed from a method to an injected BiConsumer
   - replaced lock with AtomicReference which invokes parseResponseNoResponseError
   - added result parameter to #parse & #parseResponse methods
   - #addField #addSecurityError #addFieldError #parseFieldDataArray removed
   - additional shared parse methods made static with additional result parameter